### PR TITLE
Define spacing & vertical rhythm system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,18 @@ Fonts:
 
 Apply families via `style="font-family: var(--font-headline)"` (Tailwind 4 doesn't support `font-headline` as a utility directly).
 
+## Spacing & rhythm
+
+**Full spec:** [`docs/specs/spacing.md`](docs/specs/spacing.md). Read it before adding any margin, padding, or gap.
+
+Quick reference:
+
+- **Scale:** `--spacing-3xs` (4px) through `--spacing-4xl` (128px), plus a pinned `--spacing-rhythm` (28px) for prose paragraph gaps. Tailwind utilities: `p-sm`, `gap-md`, `mt-lg`, `py-section-y`, etc. — all generated from the `@theme` tokens.
+- **Semantic tokens:** `--spacing-section-y` (between major sections), `--spacing-stack` (default vertical rhythm), `--spacing-inline` (inline gap), `--spacing-container-x` / `-x-lg` (horizontal page padding), `--spacing-card-gap`, `--spacing-hero-pb`. Use these over raw scale values when intent matters.
+- **Containers:** `max-w-reading` (700px prose), `max-w-hero` (896px hero text blocks), `max-w-content` (1280px grid). These replace `max-w-2xl/3xl/4xl/7xl/screen-xl` literals.
+- **Forbidden patterns:** raw numeric Tailwind spacing (`mt-12`, `px-6`, `py-24`, `gap-8`), arbitrary values (`mt-[72px]`), raw pixel/rem in inline styles. Use tokens or documented exceptions.
+- **Documented exceptions:** `p-0`/`m-0`/`gap-0` (explicit resets), `pb-0.5` (sub-pixel typography alignment), `max-w-[12ch]` (character-based constraint), `pt-[var(--header-height)]` (bespoke layout constants).
+
 ## Publishing Integration
 
 Content flows: `dime → compendium/ repo → AstroAdapter → src/content/articles/`

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -33,7 +33,7 @@ const placeholderBg =
 
 <a
   href={`/articles/${article.id}`}
-  class="flex flex-col gap-6 group cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-revolutionary-red rounded-sm"
+  class="flex flex-col gap-md group cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-revolutionary-red rounded-sm"
 >
   <div
     class:list={[
@@ -61,16 +61,16 @@ const placeholderBg =
         </span>
       </div>
     )}
-    <div class="absolute top-4 left-4">
+    <div class="absolute top-sm left-sm">
       <span
-        class="px-3 py-1 rounded-sm font-bold uppercase tracking-widest"
+        class="px-xs py-3xs rounded-sm font-bold uppercase tracking-widest"
         style={`font-family: var(--font-headline); font-size: var(--text-caption); ${badgeStyle(article.data.category)}`}
       >
         {cat?.name ?? article.data.category}
       </span>
     </div>
   </div>
-  <div class="space-y-3">
+  <div class="space-y-xs">
     <h3
       class="uppercase tracking-tight text-deep-charcoal group-hover:text-revolutionary-red transition-colors"
       style="font-family: var(--font-headline); font-size: var(--text-h4); line-height: 1.05"
@@ -84,7 +84,7 @@ const placeholderBg =
       {article.data.description}
     </p>
     {article.data.tags.length > 0 && (
-      <div class="flex flex-wrap gap-2 pt-1">
+      <div class="flex flex-wrap gap-2xs pt-3xs">
         {article.data.tags.map((tag) => (
           <span
             class="font-bold uppercase tracking-tighter text-deep-charcoal/60"

--- a/src/components/CategoryTiles.astro
+++ b/src/components/CategoryTiles.astro
@@ -6,16 +6,18 @@
 import { CATEGORY_LIST } from "../lib/categories";
 ---
 
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-md">
   {CATEGORY_LIST.map((cat) => (
     <a
       href={`/categories/${cat.slug}`}
-      class="p-8 px-6 rounded-lg h-64 flex flex-col justify-between group cursor-pointer hover:-translate-y-1 hover:shadow-xl transition-all shadow-md relative overflow-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-warm-gold"
+      class="p-lg px-md rounded-lg h-64 flex flex-col justify-between group cursor-pointer hover:-translate-y-1 hover:shadow-xl transition-all shadow-md relative overflow-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-warm-gold"
       style={`background:${cat.accent}`}
       aria-label={`Browse ${cat.name}`}
     >
-      <!-- Ghost icon — large, decorative, in the corner -->
-      <div class="absolute -right-8 -top-8 opacity-20 group-hover:opacity-30 transition-opacity" aria-hidden="true">
+      <!-- Ghost icon — large, decorative, in the corner.
+           The -right-lg/-top-lg offset pulls the icon partly off-canvas
+           so the clipped silhouette reads as decoration. -->
+      <div class="absolute -right-lg -top-lg opacity-20 group-hover:opacity-30 transition-opacity" aria-hidden="true">
         <span
           class="material-symbols-outlined text-[120px]"
           style="font-variation-settings: 'FILL' 1;"

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -18,15 +18,15 @@ const footerLinks = [
 ];
 ---
 
-<footer class="bg-deep-charcoal text-white py-16 px-8">
-  <div class="max-w-4xl mx-auto text-center space-y-8">
+<footer class="bg-deep-charcoal text-white py-2xl px-container-x md:px-container-x-lg">
+  <div class="max-w-hero mx-auto text-center space-y-lg">
     <p
       class="italic text-warm-gold"
       style="font-family: var(--font-label); font-size: var(--text-body-lg)"
     >
       Remembering those whose very existence defied injustice.
     </p>
-    <nav class="flex flex-wrap justify-center gap-8" aria-label="Footer navigation">
+    <nav class="flex flex-wrap justify-center gap-lg" aria-label="Footer navigation">
       {footerLinks.map((link) => {
         const active = isActive(link.href);
         return (

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -22,18 +22,18 @@ function isActive(href: string) {
 <!-- Skip to main content — WCAG 2.2 AA SC 2.4.1 -->
 <a
   href="#main-content"
-  class="sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:top-4 focus-visible:left-4 focus-visible:z-[200] focus-visible:px-4 focus-visible:py-2 focus-visible:bg-warm-gold focus-visible:text-deep-charcoal focus-visible:font-black focus-visible:uppercase focus-visible:text-sm focus-visible:rounded-sm"
-  style="font-family: var(--font-headline)"
+  class="sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:top-sm focus-visible:left-sm focus-visible:z-[200] focus-visible:px-sm focus-visible:py-2xs focus-visible:bg-warm-gold focus-visible:text-deep-charcoal focus-visible:font-black focus-visible:uppercase focus-visible:rounded-sm"
+  style="font-family: var(--font-headline); font-size: var(--text-caption)"
 >
   Skip to content
 </a>
 
-<header class="fixed top-0 w-full z-50 flex justify-between items-center px-8 py-4 backdrop-blur-md bg-deep-charcoal/85">
+<header class="fixed top-0 w-full z-50 flex justify-between items-center px-lg py-sm backdrop-blur-md bg-deep-charcoal/85">
 
   <!-- Logo lockup -->
   <a
     href="/"
-    class="flex items-center gap-3 group focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-warm-gold rounded-sm"
+    class="flex items-center gap-xs group focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-warm-gold rounded-sm"
     aria-label="Acts of Defiance — home"
   >
     <!-- Icon with animated gold glow -->
@@ -58,7 +58,7 @@ function isActive(href: string) {
   </a>
 
   <!-- Desktop nav -->
-  <nav class="hidden md:flex items-center gap-8" aria-label="Main navigation">
+  <nav class="hidden md:flex items-center gap-lg" aria-label="Main navigation">
     {navItems.map((item) => {
       const active = isActive(item.href);
       return (
@@ -85,7 +85,8 @@ function isActive(href: string) {
   <button
     id="mobile-menu-btn"
     type="button"
-    class="md:hidden text-white p-2 -mr-2 rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-warm-gold"
+    class="md:hidden text-white p-2xs rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-warm-gold"
+    style="margin-right: calc(-1 * var(--spacing-2xs))"
     aria-label="Open navigation menu"
     aria-expanded="false"
     aria-controls="mobile-menu"
@@ -112,7 +113,7 @@ function isActive(href: string) {
         <a
           href={item.href}
           class:list={[
-            "flex items-center px-8 py-4 font-medium tracking-wide uppercase transition-colors border-b border-white/10",
+            "flex items-center px-lg py-sm font-medium tracking-wide uppercase transition-colors border-b border-white/10",
             "focus-visible:outline focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-warm-gold",
             {
               "text-warm-gold": active,

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -28,7 +28,7 @@ function isActive(href: string) {
   Skip to content
 </a>
 
-<header class="fixed top-0 w-full z-50 flex justify-between items-center px-lg py-sm backdrop-blur-md bg-deep-charcoal/85">
+<header class="fixed top-0 w-full z-50 flex justify-between items-center px-container-x md:px-container-x-lg py-sm backdrop-blur-md bg-deep-charcoal/85">
 
   <!-- Logo lockup -->
   <a
@@ -85,8 +85,7 @@ function isActive(href: string) {
   <button
     id="mobile-menu-btn"
     type="button"
-    class="md:hidden text-white p-2xs rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-warm-gold"
-    style="margin-right: calc(-1 * var(--spacing-2xs))"
+    class="md:hidden text-white p-2xs -mr-2xs rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-warm-gold"
     aria-label="Open navigation menu"
     aria-expanded="false"
     aria-controls="mobile-menu"
@@ -113,7 +112,7 @@ function isActive(href: string) {
         <a
           href={item.href}
           class:list={[
-            "flex items-center px-lg py-sm font-medium tracking-wide uppercase transition-colors border-b border-white/10",
+            "flex items-center px-container-x md:px-container-x-lg py-sm font-medium tracking-wide uppercase transition-colors border-b border-white/10",
             "focus-visible:outline focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-warm-gold",
             {
               "text-warm-gold": active,

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -112,7 +112,7 @@ function isActive(href: string) {
         <a
           href={item.href}
           class:list={[
-            "flex items-center px-container-x md:px-container-x-lg py-sm font-medium tracking-wide uppercase transition-colors border-b border-white/10",
+            "flex items-center px-container-x py-sm font-medium tracking-wide uppercase transition-colors border-b border-white/10",
             "focus-visible:outline focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-warm-gold",
             {
               "text-warm-gold": active,

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -7,18 +7,18 @@
 //     <Content />
 //   </Prose>
 //
-// All sizes pull from the type scale tokens. See docs/specs/typography.md.
+// Reading measure comes from the --container-reading token (700px).
+// All sizes pull from the type scale tokens. See docs/specs/typography.md
+// and docs/specs/spacing.md.
 
 interface Props {
-  /** Optional max-width for the readable column. Defaults to 700px. */
-  maxWidth?: string;
   /** Optional className override / extension. */
   class?: string;
 }
 
-const { maxWidth = "700px", class: classOverride = "" } = Astro.props;
+const { class: classOverride = "" } = Astro.props;
 ---
 
-<div class={`prose mx-auto ${classOverride}`} style={`max-width:${maxWidth}`}>
+<div class={`prose mx-auto max-w-reading ${classOverride}`}>
   <slot />
 </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,7 +10,10 @@ interface Props {
   bodyClass?: string;
 }
 
-const { title, description, mainClass = "pt-16", bodyClass = "" } = Astro.props;
+// Default `mainClass` reserves exactly the header's height as top padding,
+// so content slots cleanly below the fixed nav. Pages that render a hero
+// extending behind the header (home, article, about) pass mainClass="".
+const { title, description, mainClass = "pt-[var(--header-height)]", bodyClass = "" } = Astro.props;
 const siteName = "Acts of Defiance";
 const fullTitle = title === siteName ? title : `${title} | ${siteName}`;
 ---

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -32,22 +32,22 @@ const { Content } = await render(entry);
     <div class="absolute inset-0 bg-gradient-to-t from-deep-charcoal via-transparent to-transparent"></div>
   </header>
 
-  <!-- Main content overlaps hero by 24 -->
-  <div class="max-w-screen-xl mx-auto px-6 -mt-24 relative z-10">
+  <!-- Main content overlaps hero by --spacing-3xl (-mt: negative 3xl via calc) -->
+  <div class="max-w-content mx-auto px-container-x md:px-container-x-lg relative z-10" style="margin-top: calc(-1 * var(--spacing-3xl))">
 
     <!-- Page header: white card -->
-    <div class="bg-white p-8 md:p-12 shadow-sm">
-      <div class="flex flex-col items-start gap-4">
+    <div class="bg-white p-lg md:p-xl shadow-sm">
+      <div class="flex flex-col items-start gap-sm">
         <!-- Headline -->
         <h1
-          class="uppercase tracking-tighter max-w-4xl text-deep-charcoal"
+          class="uppercase tracking-tighter max-w-hero text-deep-charcoal"
           style="font-family: var(--font-headline); font-size: var(--text-h1); line-height: 1"
         >
           {entry.data.title}
         </h1>
         <!-- Tagline -->
         <p
-          class="italic text-on-surface-variant max-w-3xl"
+          class="italic text-on-surface-variant max-w-hero"
           style="font-family: var(--font-label); font-size: var(--text-body-lg)"
         >
           {entry.data.tagline}
@@ -56,19 +56,19 @@ const { Content } = await render(entry);
     </div>
 
     <!-- Manifesto body — shared Prose component (no page-level scoped CSS) -->
-    <article class="bg-parchment py-16 md:py-24 px-6 md:px-0">
+    <article class="bg-parchment py-2xl md:py-section-y px-container-x md:px-0">
       <Prose>
         <Content />
       </Prose>
     </article>
 
     <!-- What we cover — category tile grid -->
-    <section class="py-24 border-t border-outline-variant">
-      <SectionHead variant="editorial" class="mb-12 text-center">
+    <section class="py-section-y border-t border-outline-variant">
+      <SectionHead variant="editorial" class="mb-xl text-center">
         What we cover
       </SectionHead>
       <CategoryTiles />
     </section>
 
-  </div><!-- /max-w-screen-xl -->
+  </div><!-- /max-w-content -->
 </BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -33,7 +33,7 @@ const { Content } = await render(entry);
   </header>
 
   <!-- Main content overlaps hero by --spacing-3xl (-mt: negative 3xl via calc) -->
-  <div class="max-w-content mx-auto px-container-x md:px-container-x-lg relative z-10" style="margin-top: calc(-1 * var(--spacing-3xl))">
+  <div class="max-w-content mx-auto px-container-x md:px-container-x-lg relative z-10 -mt-3xl">
 
     <!-- Page header: white card -->
     <div class="bg-white p-lg md:p-xl shadow-sm">

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -72,7 +72,7 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
   </header>
 
   <!-- Main content overlaps hero (negative margin = -1 × --spacing-3xl) -->
-  <div class="max-w-content mx-auto px-container-x md:px-container-x-lg relative z-10" style="margin-top: calc(-1 * var(--spacing-3xl))">
+  <div class="max-w-content mx-auto px-container-x md:px-container-x-lg relative z-10 -mt-3xl">
 
     <!-- Article header: white card -->
     <div class="bg-white p-lg md:p-xl shadow-sm">

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -71,16 +71,16 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
     <div class="absolute inset-0 bg-gradient-to-t from-deep-charcoal via-transparent to-transparent"></div>
   </header>
 
-  <!-- Main content overlaps hero by 24 -->
-  <div class="max-w-screen-xl mx-auto px-6 -mt-24 relative z-10">
+  <!-- Main content overlaps hero (negative margin = -1 × --spacing-3xl) -->
+  <div class="max-w-content mx-auto px-container-x md:px-container-x-lg relative z-10" style="margin-top: calc(-1 * var(--spacing-3xl))">
 
     <!-- Article header: white card -->
-    <div class="bg-white p-8 md:p-12 shadow-sm">
-      <div class="flex flex-col items-start gap-4">
+    <div class="bg-white p-lg md:p-xl shadow-sm">
+      <div class="flex flex-col items-start gap-sm">
 
         <!-- Category pill -->
         <span
-          class="px-4 py-1 font-black uppercase tracking-widest rounded-full"
+          class="px-sm py-3xs font-black uppercase tracking-widest rounded-full"
           style={`font-family: var(--font-headline); font-size: var(--text-caption); ${badge}`}
         >
           {CATEGORIES[article.data.category as CategorySlug]?.name ?? article.data.category}
@@ -88,22 +88,22 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
 
         <!-- Headline -->
         <h1
-          class="uppercase tracking-tighter max-w-4xl text-on-surface"
+          class="uppercase tracking-tighter max-w-hero text-on-surface"
           style="font-family: var(--font-headline); font-size: var(--text-h1); line-height: 1"
         >
           {article.data.title}
         </h1>
 
         <!-- Date + tags row -->
-        <div class="flex flex-wrap items-center gap-4 text-on-surface-variant mt-4" style="font-size: var(--text-caption)">
+        <div class="flex flex-wrap items-center gap-sm text-on-surface-variant mt-sm" style="font-size: var(--text-caption)">
           <span style="font-family: var(--font-label)" class="italic">
             {dateStr}
           </span>
           {article.data.tags.length > 0 && (
-            <div class="flex flex-wrap gap-2">
+            <div class="flex flex-wrap gap-2xs">
               {article.data.tags.map((tag) => (
                 <span
-                  class="px-2 py-0.5 bg-surface-container-high uppercase font-bold tracking-tight text-on-surface-variant"
+                  class="px-2xs py-3xs bg-surface-container-high uppercase font-bold tracking-tight text-on-surface-variant"
                   style="font-size: var(--text-caption)"
                 >
                   {tag}
@@ -119,32 +119,32 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
         Deep Dive split ships when dime emits the short version; for now
         Deep Dive is the only content variant. See ticket for details.
       -->
-      <div class="flex gap-4 mt-12 border-t border-outline-variant pt-8">
+      <div class="flex gap-sm mt-xl border-t border-outline-variant pt-lg">
         <!-- Short Read (inactive) -->
-        <div class="flex-1 text-left p-6 bg-surface-container text-on-surface cursor-default">
-          <div class="uppercase font-bold tracking-widest opacity-60 mb-2" style="font-family: var(--font-headline); font-size: var(--text-caption)">
+        <div class="flex-1 text-left p-md bg-surface-container text-on-surface cursor-default">
+          <div class="uppercase font-bold tracking-widest opacity-60 mb-2xs" style="font-family: var(--font-headline); font-size: var(--text-caption)">
             Short Read
           </div>
           <div class="font-bold leading-tight" style="font-family: var(--font-headline); font-size: var(--text-body-lg)">
             The Story
           </div>
-          <div class="h-1 w-0 bg-primary-container mt-4"></div>
+          <div class="h-1 w-0 bg-primary-container mt-sm"></div>
         </div>
         <!-- Deep Dive (active) -->
-        <div class="flex-1 text-left p-6 bg-white border-b-4 border-primary-container shadow-md cursor-default">
-          <div class="uppercase font-bold tracking-widest text-primary-md mb-2" style="font-family: var(--font-headline); font-size: var(--text-caption)">
+        <div class="flex-1 text-left p-md bg-white border-b-4 border-primary-container shadow-md cursor-default">
+          <div class="uppercase font-bold tracking-widest text-primary-md mb-2xs" style="font-family: var(--font-headline); font-size: var(--text-caption)">
             Full Research
           </div>
           <div class="font-bold leading-tight text-on-surface" style="font-family: var(--font-headline); font-size: var(--text-body-lg)">
             Deep Dive
           </div>
-          <div class="h-1 w-full bg-primary-container mt-4"></div>
+          <div class="h-1 w-full bg-primary-container mt-sm"></div>
         </div>
       </div>
     </div>
 
     <!-- Article body: parchment background -->
-    <article class="bg-parchment py-16 md:py-24 px-6 md:px-0">
+    <article class="bg-parchment py-2xl md:py-section-y px-container-x md:px-0">
       <Prose>
         <Content />
       </Prose>
@@ -152,18 +152,18 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
 
     <!-- Related articles -->
     {related.length > 0 && (
-      <section class="py-24 border-t border-outline-variant">
-        <div class="mb-12">
+      <section class="py-section-y border-t border-outline-variant">
+        <div class="mb-xl">
           <SectionHead variant="structural">More acts of defiance</SectionHead>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-lg">
           {related.map((rel) => {
             const tint = tintFor(rel.data.category);
             const relBadge = badgeStyle(rel.data.category);
             const relCat = CATEGORIES[rel.data.category as CategorySlug];
             return (
               <a href={`/articles/${rel.id}`} class="group cursor-pointer block">
-                <div class="aspect-[4/5] bg-surface-container-highest relative overflow-hidden mb-6">
+                <div class="aspect-[4/5] bg-surface-container-highest relative overflow-hidden mb-md">
                   {rel.data.images?.hero ? (
                     <img
                       src={`/images/articles/${rel.data.images.hero}`}
@@ -179,15 +179,15 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
                     class="absolute inset-0 mix-blend-multiply opacity-20 group-hover:opacity-0 transition-opacity"
                     style={tint}
                   ></div>
-                  <div class="absolute bottom-6 left-6 right-6">
+                  <div class="absolute bottom-md left-md right-md">
                     <span
-                      class="px-3 py-1 font-black uppercase tracking-widest rounded-none"
+                      class="px-xs py-3xs font-black uppercase tracking-widest rounded-none"
                       style={`font-family: var(--font-headline); font-size: var(--text-caption); ${relBadge}`}
                     >
                       {relCat?.name ?? rel.data.category}
                     </span>
                     <h4
-                      class="text-white uppercase mt-2 drop-shadow-lg"
+                      class="text-white uppercase mt-2xs drop-shadow-lg"
                       style="font-family: var(--font-headline); font-size: var(--text-h4); line-height: 1"
                     >
                       {rel.data.title}
@@ -201,6 +201,6 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
       </section>
     )}
 
-  </div><!-- /max-w-screen-xl -->
+  </div><!-- /max-w-content -->
 
 </BaseLayout>

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -31,20 +31,20 @@ const tags = [...tagSet].sort();
 <BaseLayout
   title={category.name}
   description={category.tagline}
-  mainClass="pt-16"
+  mainClass="pt-[var(--header-height)]"
   bodyClass="bg-surface"
 >
   <!-- Page header: parchment-textured block with massive category title + tag filter row -->
-  <header class="parchment-texture-category border-b border-outline-variant/30 pt-20 pb-16 px-6 md:px-12">
-    <div class="max-w-7xl mx-auto">
+  <header class="parchment-texture-category border-b border-outline-variant/30 pt-section-y pb-2xl px-container-x md:px-container-x-lg">
+    <div class="max-w-content mx-auto">
       <h1
-        class="uppercase tracking-tighter mb-6"
+        class="uppercase tracking-tighter mb-md"
         style={`font-family: var(--font-headline); font-size: var(--text-display); line-height: 0.9; color:${category.accent}`}
       >
         {category.name}
       </h1>
       <p
-        class="font-medium text-deep-charcoal max-w-3xl leading-snug mb-12"
+        class="font-medium text-deep-charcoal max-w-hero leading-snug mb-xl"
         style="font-family: var(--font-body); font-size: var(--text-body-lg)"
       >
         {category.tagline}
@@ -56,11 +56,11 @@ const tags = [...tagSet].sort();
         properly conveyed as such to assistive technologies (the
         `disabled` attribute handles aria semantics by default).
       -->
-      <div class="flex flex-wrap gap-3" role="group" aria-label="Filter by tag (coming soon)">
+      <div class="flex flex-wrap gap-xs" role="group" aria-label="Filter by tag (coming soon)">
         <button
           type="button"
           disabled
-          class="px-6 py-2 bg-deep-charcoal text-surface font-bold uppercase tracking-widest focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-revolutionary-red opacity-90 cursor-not-allowed"
+          class="px-md py-2xs bg-deep-charcoal text-surface font-bold uppercase tracking-widest focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-revolutionary-red opacity-90 cursor-not-allowed"
           style="font-family: var(--font-headline); font-size: var(--text-caption)"
           aria-pressed="true"
         >
@@ -70,7 +70,7 @@ const tags = [...tagSet].sort();
           <button
             type="button"
             disabled
-            class="px-6 py-2 bg-surface-container-high text-on-surface-variant font-bold uppercase tracking-widest transition-colors duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-revolutionary-red opacity-60 cursor-not-allowed"
+            class="px-md py-2xs bg-surface-container-high text-on-surface-variant font-bold uppercase tracking-widest transition-colors duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-revolutionary-red opacity-60 cursor-not-allowed"
             style="font-family: var(--font-headline); font-size: var(--text-caption)"
             aria-pressed="false"
           >
@@ -82,22 +82,22 @@ const tags = [...tagSet].sort();
   </header>
 
   <!-- Article feed -->
-  <section class="max-w-7xl mx-auto px-6 md:px-12 py-20">
+  <section class="max-w-content mx-auto px-container-x md:px-container-x-lg py-section-y">
     {articles.length === 0 ? (
-      <div class="py-24 text-center">
+      <div class="py-section-y text-center">
         <p
           class="italic text-deep-charcoal/60"
           style="font-family: var(--font-label); font-size: var(--text-body-lg)"
         >
           No {category.name.toLowerCase()} stories yet.
         </p>
-        <p class="mt-4 text-deep-charcoal/50" style="font-size: var(--text-body)">
+        <p class="mt-sm text-deep-charcoal/50" style="font-size: var(--text-body)">
           Content will flow here from dime.
         </p>
       </div>
     ) : (
       <>
-        <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-12 list-none p-0">
+        <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-card-gap list-none p-0">
           {articles.map((article, i) => (
             <li>
               <ArticleCard article={article} bordered variant={i} />
@@ -110,11 +110,11 @@ const tags = [...tagSet].sort();
           ticket. Button is `disabled` until pagination is wired so it
           can't trap keyboard users in a dead-end interaction.
         -->
-        <div class="mt-24 flex justify-center">
+        <div class="mt-section-y flex justify-center">
           <button
             type="button"
             disabled
-            class="px-12 py-4 border-2 border-deep-charcoal text-deep-charcoal font-black uppercase tracking-widest opacity-50 cursor-not-allowed transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-revolutionary-red"
+            class="px-xl py-sm border-2 border-deep-charcoal text-deep-charcoal font-black uppercase tracking-widest opacity-50 cursor-not-allowed transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-revolutionary-red"
             style="font-family: var(--font-headline); font-size: var(--text-caption)"
           >
             Load More Archives

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -31,7 +31,6 @@ const tags = [...tagSet].sort();
 <BaseLayout
   title={category.name}
   description={category.tagline}
-  mainClass="pt-[var(--header-height)]"
   bodyClass="bg-surface"
 >
   <!-- Page header: parchment-textured block with massive category title + tag filter row -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,10 +16,10 @@ const articles = (await getCollection("articles", ({ data }) => !data.draft))
 >
   <!-- Hero Section: cinematic. Extends behind fixed header (h = 768 + 64) so no parchment gap shows. -->
   <section class="relative w-full h-[832px] min-h-[564px] overflow-hidden bg-black">
-    <div class="absolute inset-0 hero-gradient flex flex-col justify-end px-8 md:px-16 pb-16">
-      <div class="max-w-4xl space-y-6">
+    <div class="absolute inset-0 hero-gradient flex flex-col justify-end px-container-x md:px-container-x-lg pb-hero-pb">
+      <div class="max-w-hero space-y-stack">
         <span
-          class="inline-block bg-tertiary text-white px-4 py-1 rounded-full font-bold uppercase tracking-widest"
+          class="inline-block bg-tertiary text-white px-md py-3xs rounded-full font-bold uppercase tracking-widest"
           style="font-family: var(--font-headline); font-size: var(--text-caption)"
         >
           Manifesto
@@ -30,15 +30,15 @@ const articles = (await getCollection("articles", ({ data }) => !data.draft))
         >
           Defiance is an act of hope.
         </h1>
-        <p class="text-gray-200 max-w-2xl leading-relaxed" style="font-size: var(--text-body-lg)">
+        <p class="text-gray-200 max-w-hero leading-relaxed" style="font-size: var(--text-body-lg)">
           Remembering those whose very existence defied injustice — artists,
           organizers, movements, and ordinary people whose existence was itself
           a form of resistance.
         </p>
-        <div class="pt-4">
+        <div class="pt-sm">
           <a
             href="/about"
-            class="inline-flex items-center gap-2 bg-primary text-white px-8 py-4 rounded-lg font-black uppercase tracking-widest hover:bg-opacity-90 transition-all active:scale-95 group focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-warm-gold"
+            class="inline-flex items-center gap-2xs bg-primary text-white px-lg py-sm rounded-lg font-black uppercase tracking-widest hover:bg-opacity-90 transition-all active:scale-95 group focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-warm-gold"
             style="font-family: var(--font-headline); font-size: var(--text-caption)"
           >
             Read the Manifesto
@@ -50,18 +50,18 @@ const articles = (await getCollection("articles", ({ data }) => !data.draft))
   </section>
 
   <!-- Recent Articles Feed -->
-  <section class="py-24 px-8 md:px-16">
-    <div class="max-w-7xl mx-auto">
-      <div class="mb-12 border-b-4 border-primary pb-4">
+  <section class="py-section-y px-container-x md:px-container-x-lg">
+    <div class="max-w-content mx-auto">
+      <div class="mb-xl border-b-4 border-primary pb-md">
         <SectionHead variant="editorial">Recent stories</SectionHead>
       </div>
 
       {articles.length === 0 ? (
-        <p class="text-center text-deep-charcoal/50 py-16 italic" style="font-family: var(--font-label)">
+        <p class="text-center text-deep-charcoal/50 py-2xl italic" style="font-family: var(--font-label)">
           Content will flow here from dime.
         </p>
       ) : (
-        <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-12 list-none p-0">
+        <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-card-gap list-none p-0">
           {articles.map((article) => (
             <li>
               <ArticleCard article={article} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,7 +19,7 @@ const articles = (await getCollection("articles", ({ data }) => !data.draft))
     <div class="absolute inset-0 hero-gradient flex flex-col justify-end px-container-x md:px-container-x-lg pb-hero-pb">
       <div class="max-w-hero space-y-stack">
         <span
-          class="inline-block bg-tertiary text-white px-md py-3xs rounded-full font-bold uppercase tracking-widest"
+          class="inline-block bg-tertiary text-white px-sm py-3xs rounded-full font-bold uppercase tracking-widest"
           style="font-family: var(--font-headline); font-size: var(--text-caption)"
         >
           Manifesto
@@ -52,7 +52,7 @@ const articles = (await getCollection("articles", ({ data }) => !data.draft))
   <!-- Recent Articles Feed -->
   <section class="py-section-y px-container-x md:px-container-x-lg">
     <div class="max-w-content mx-auto">
-      <div class="mb-xl border-b-4 border-primary pb-md">
+      <div class="mb-xl border-b-4 border-primary pb-sm">
         <SectionHead variant="editorial">Recent stories</SectionHead>
       </div>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -64,6 +64,45 @@
   /* Layout tokens */
   --header-height: 72px;
 
+  /* Spacing scale — see docs/specs/spacing.md
+   *
+   * Stepped (not fluid) atomic scale, every value is n × 0.25rem. The
+   * scale mixes linear small steps (fine UI control) with geometric
+   * large steps (dramatic section breaks), plus one pinned
+   * `--spacing-rhythm` value (1.75rem = 28px) corresponding to one line
+   * of body text at the max viewport.
+   *
+   * Available as Tailwind utilities: p-3xs, gap-sm, mt-rhythm, etc.
+   */
+  --spacing-3xs:    0.25rem;  /*   4px */
+  --spacing-2xs:    0.5rem;   /*   8px */
+  --spacing-xs:     0.75rem;  /*  12px */
+  --spacing-sm:     1rem;     /*  16px */
+  --spacing-md:     1.5rem;   /*  24px */
+  --spacing-rhythm: 1.75rem;  /*  28px — pinned to body line-height at max viewport */
+  --spacing-lg:     2rem;     /*  32px */
+  --spacing-xl:     3rem;     /*  48px */
+  --spacing-2xl:    4rem;     /*  64px */
+  --spacing-3xl:    6rem;     /*  96px */
+  --spacing-4xl:    8rem;     /* 128px */
+
+  /* Semantic spacing layer — intent-carrying aliases for the scale.
+   * Use these whenever intent is stronger than the specific value. */
+  --spacing-section-y:        var(--spacing-3xl);  /* between major page sections */
+  --spacing-stack:            var(--spacing-lg);   /* default vertical stack rhythm */
+  --spacing-inline:           var(--spacing-xs);   /* default inline element gap */
+  --spacing-prose-paragraph:  var(--spacing-rhythm); /* body paragraph separation */
+  --spacing-container-x:      var(--spacing-md);   /* horizontal page padding — mobile */
+  --spacing-container-x-lg:   var(--spacing-xl);   /* horizontal page padding — tablet+ */
+  --spacing-card-gap:         var(--spacing-xl);   /* grid gap between article cards */
+  --spacing-hero-pb:          var(--spacing-xl);   /* bottom padding inside cinematic heroes */
+
+  /* Container max-widths — semantic content-width tokens.
+   * The <Container> primitive in #9 will consume these. */
+  --container-reading:   43.75rem;  /*  700px — long-form reading measure */
+  --container-hero:    56rem;     /*  896px — hero headline + supporting copy block */
+  --container-content: 80rem;     /* 1280px — page-width grid container */
+
   /* Typography — see docs/specs/typography.md
    *
    * Type scale: Augmented Fourth (ratio √2 ≈ 1.4142)

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -12,8 +12,11 @@
   color: color-mix(in srgb, var(--color-on-surface) 90%, transparent);
 }
 
+/* Paragraph rhythm — pinned to --spacing-prose-paragraph (28px = one line of
+ * body text at max viewport). Heading margins below override this with their
+ * own em-based values because they should scale with the heading font size. */
 .prose > * + * {
-  margin-top: 1.5em;
+  margin-top: var(--spacing-prose-paragraph);
 }
 
 .prose p {


### PR DESCRIPTION
## Summary

Establishes the spacing & vertical rhythm foundation for Acts of Defiance (closes #7). Introduces an atomic `--spacing-*` scale with a rhythmic semantic layer, container tokens, and refactors every page/component to consume them.

Closes #7

## Changes

- **Spec** — `docs/specs/spacing.md`: stepped atomic base (11 steps, 4–128px) + rhythmic `--spacing-rhythm` (28px) pinned to body line-height at max viewport. Documents 8 semantic tokens, 3 container tokens, strict usage rules, and 5 exception paths.
- **Tokens** — `src/styles/global.css` `@theme`: adds `--spacing-*` scale, semantic layer (`--spacing-section-y`, `--spacing-stack`, `--spacing-container-x`, `--spacing-card-gap`, …), and `--container-reading` / `--container-hero` / `--container-content`. Tailwind 4 auto-generates `p-sm`, `gap-md`, `py-section-y`, `max-w-content`, etc. from these.
- **Refactor** — all pages (home, about, article, category) and shared components (ArticleCard, CategoryTiles, Header, Footer, Prose) now use tokens. No raw numeric Tailwind spacing or arbitrary values remain in page templates.
- **Bugfix** — `BaseLayout.astro` `pt-16` (64px) was 8px shy of the 72px header; now `pt-[var(--header-height)]`.
- **Bugfix** — article and about pages were missing `md:px-container-x-lg` responsive upgrade.
- **Docs** — promotes Spacing from "pending" in `design-standards.md` sub-spec index; adds Spacing quick-reference to `CLAUDE.md`.

## Verification

- \`bun run build\` — 7 routes, clean
- Playwright smoke test at 1440px viewport confirmed tokens resolve at runtime:
  - \`--spacing-section-y\` → 96px
  - \`--spacing-card-gap\` → 48px
  - \`--container-content\` → 1280px
  - \`--header-height\` → 72px
  - Overlap containers use 48px horizontal padding on tablet+

## Checklist

- [x] \`bun run build\` succeeds
- [x] Visually verified via Playwright at desktop viewport
- [x] No raw numeric spacing / arbitrary values in page templates
- [x] Spec committed alongside implementation
- [x] CLAUDE.md updated with quick reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)