### PR TITLE
Define layout primitives (Container, Stack, Cluster, Grid, Center)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,5 @@ foobar/
 # Playwright session cache
 .playwright-mcp/
 
-# Root-level test screenshots from local visual verification runs
-/about-pw.png
-/about-typography.png
-/cat-mobile.png
-/home-fixed.png
-/home-mobile.png
+# Root-level screenshots from local visual verification runs
+/*.png

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,20 @@ Quick reference:
 - **Forbidden patterns:** `transition-colors`/`transition-all`/`duration-300`/`ease-in-out` (or any Tailwind default transition utility). Hardcoded ms values. `cubic-bezier(...)` literals outside `global.css`. Bare `:hover` color swaps without going through `.aod-brand-link` for nav links.
 - **Reduced motion:** global `@media (prefers-reduced-motion: reduce)` rule in `global.css` collapses all transitions and animations to `0.01ms`.
 
+## Layout primitives
+
+**Full spec:** [`docs/specs/layout.md`](docs/specs/layout.md). Read it before adding any page-level layout.
+
+Quick reference — all in `src/components/layout/`:
+
+- **`<Container width="content|hero|reading">`** — max-width + horizontal padding. Default: `content` (1280px). Every page section should be wrapped.
+- **`<Stack gap="token">`** — vertical rhythm (`flex flex-col gap-{token}`). Default gap: `stack` (32px). Add `class="items-start"` when children should be intrinsically sized.
+- **`<Cluster gap="token" justify="..." align="...">`** — wrapping inline group (`flex flex-wrap`). Default gap: `inline` (12px).
+- **`<Grid cols="1 md:2 lg:3" gap="token">`** — responsive column grid. Default gap: `card-gap` (48px). Cols string parsed into breakpoint classes.
+- **`<Center>`** — `text-center` wrapper for headings, empty states.
+- **All accept `as` prop** for semantic HTML (`as="section"`, `as="ul"`, `as="nav"`).
+- **Forbidden patterns in page templates:** raw `max-w-* mx-auto px-*`, `space-y-*`, `flex flex-wrap gap-*`, `grid grid-cols-*`. Use the primitives.
+
 ## Spacing & rhythm
 
 **Full spec:** [`docs/specs/spacing.md`](docs/specs/spacing.md). Read it before adding any margin, padding, or gap.

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -1,6 +1,8 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import { badgeStyle, CATEGORIES, type CategorySlug } from "../lib/categories";
+import Stack from "./layout/Stack.astro";
+import Cluster from "./layout/Cluster.astro";
 
 interface Props {
   article: CollectionEntry<"articles">;
@@ -70,7 +72,7 @@ const placeholderBg =
       </span>
     </div>
   </div>
-  <div class="space-y-xs px-md pb-md">
+  <Stack gap="xs" class="px-md pb-md">
     <h3
       class="aod-brand-card__title uppercase tracking-tight text-deep-charcoal"
       style="font-family: var(--font-headline); font-size: var(--text-h4); line-height: 1.05"
@@ -84,7 +86,7 @@ const placeholderBg =
       {article.data.description}
     </p>
     {article.data.tags.length > 0 && (
-      <div class="flex flex-wrap gap-2xs pt-3xs">
+      <Cluster gap="2xs" class="pt-3xs">
         {article.data.tags.map((tag) => (
           <span
             class="font-bold uppercase tracking-tighter text-deep-charcoal/60"
@@ -93,7 +95,7 @@ const placeholderBg =
             #{tag}
           </span>
         ))}
-      </div>
+      </Cluster>
     )}
-  </div>
+  </Stack>
 </a>

--- a/src/components/CategoryTiles.astro
+++ b/src/components/CategoryTiles.astro
@@ -4,9 +4,10 @@
 // upper-left, category name at the bottom. Used on the about page
 // (and intended for the home page newsletter section eventually).
 import { CATEGORY_LIST } from "../lib/categories";
+import Grid from "./layout/Grid.astro";
 ---
 
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-md">
+<Grid cols="1 sm:2 lg:4" gap="md">
   {CATEGORY_LIST.map((cat) => (
     <a
       href={`/categories/${cat.slug}`}
@@ -46,4 +47,4 @@ import { CATEGORY_LIST } from "../lib/categories";
       </h3>
     </a>
   ))}
-</div>
+</Grid>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,8 @@
 ---
 import { CATEGORY_LIST } from "../lib/categories";
+import Container from "./layout/Container.astro";
+import Stack from "./layout/Stack.astro";
+import Cluster from "./layout/Cluster.astro";
 
 const currentPath = Astro.url.pathname;
 
@@ -19,33 +22,35 @@ const footerLinks = [
 ---
 
 <footer class="bg-deep-charcoal text-white py-2xl px-container-x md:px-container-x-lg">
-  <div class="max-w-hero mx-auto text-center space-y-lg">
-    <p
-      class="italic text-warm-gold"
-      style="font-family: var(--font-label); font-size: var(--text-body-lg)"
-    >
-      Remembering those whose very existence defied injustice.
-    </p>
-    <nav class="flex flex-wrap justify-center gap-lg" aria-label="Footer navigation">
-      {footerLinks.map((link) => {
-        const active = isActive(link.href);
-        return (
-          <a
-            href={link.href}
-            aria-current={active ? "page" : undefined}
-            class:list={[
-              "aod-brand-link aod-focus-ring uppercase tracking-wide rounded-sm",
-              {
-                "font-bold": active,
-                "text-white/70": !active,
-              },
-            ]}
-            style="font-family: var(--font-headline); font-size: var(--text-caption)"
-          >
-            {link.label}
-          </a>
-        );
-      })}
-    </nav>
-  </div>
+  <Container width="hero" class="!px-0 text-center">
+    <Stack gap="lg">
+      <p
+        class="italic text-warm-gold"
+        style="font-family: var(--font-label); font-size: var(--text-body-lg)"
+      >
+        Remembering those whose very existence defied injustice.
+      </p>
+      <Cluster as="nav" gap="lg" justify="center" aria-label="Footer navigation">
+        {footerLinks.map((link) => {
+          const active = isActive(link.href);
+          return (
+            <a
+              href={link.href}
+              aria-current={active ? "page" : undefined}
+              class:list={[
+                "aod-brand-link aod-focus-ring uppercase tracking-wide rounded-sm",
+                {
+                  "font-bold": active,
+                  "text-white/70": !active,
+                },
+              ]}
+              style="font-family: var(--font-headline); font-size: var(--text-caption)"
+            >
+              {link.label}
+            </a>
+          );
+        })}
+      </Cluster>
+    </Stack>
+  </Container>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -22,7 +22,7 @@ const footerLinks = [
 ---
 
 <footer class="bg-deep-charcoal text-white py-2xl px-container-x md:px-container-x-lg">
-  <Container width="hero" class="!px-0 text-center">
+  <Container width="hero" padded={false} class="text-center">
     <Stack gap="lg">
       <p
         class="italic text-warm-gold"

--- a/src/components/layout/Center.astro
+++ b/src/components/layout/Center.astro
@@ -1,0 +1,32 @@
+---
+// Center — horizontally centers content via text-center.
+//
+// A thin wrapper for the common "center a heading or empty-state message"
+// pattern. For centering a block with max-width, use Container instead.
+//
+// Usage:
+//   <Center>
+//     <SectionHead variant="editorial">What we cover</SectionHead>
+//   </Center>
+//   <Center class="py-section-y">
+//     <p>No stories yet.</p>
+//   </Center>
+
+interface Props {
+  /** HTML element to render. Default: div. */
+  as?: string;
+  /** Extra classes appended after the layout classes. */
+  class?: string;
+  [key: string]: any;
+}
+
+const {
+  as: Tag = "div",
+  class: className = "",
+  ...rest
+} = Astro.props;
+---
+
+<Tag class:list={["text-center", className]} {...rest}>
+  <slot />
+</Tag>

--- a/src/components/layout/Cluster.astro
+++ b/src/components/layout/Cluster.astro
@@ -1,0 +1,61 @@
+---
+// Cluster — wrapping inline group with token-based gap.
+//
+// For chip rows, tag lists, nav link groups, button sets — anything that
+// wraps naturally and needs consistent inline spacing.
+//
+// Usage:
+//   <Cluster>                                  <!-- default gap: inline (12px) -->
+//   <Cluster gap="2xs">                        <!-- tighter: 8px -->
+//   <Cluster gap="lg" justify="center">        <!-- centered footer nav -->
+
+interface Props {
+  /** Spacing token name for the gap (maps to gap-{token}). */
+  gap?: string;
+  /** Justify-content value. */
+  justify?: "start" | "center" | "end" | "between";
+  /** Align-items value. */
+  align?: "start" | "center" | "end" | "baseline";
+  /** HTML element to render. Default: div. */
+  as?: string;
+  /** Extra classes appended after the layout classes. */
+  class?: string;
+  [key: string]: any;
+}
+
+const justifyMap: Record<string, string> = {
+  start: "justify-start",
+  center: "justify-center",
+  end: "justify-end",
+  between: "justify-between",
+};
+
+const alignMap: Record<string, string> = {
+  start: "items-start",
+  center: "items-center",
+  end: "items-end",
+  baseline: "items-baseline",
+};
+
+const {
+  gap = "inline",
+  justify,
+  align,
+  as: Tag = "div",
+  class: className = "",
+  ...rest
+} = Astro.props;
+---
+
+<Tag
+  class:list={[
+    "flex flex-wrap",
+    `gap-${gap}`,
+    justify && justifyMap[justify],
+    align && alignMap[align],
+    className,
+  ]}
+  {...rest}
+>
+  <slot />
+</Tag>

--- a/src/components/layout/Container.astro
+++ b/src/components/layout/Container.astro
@@ -10,10 +10,13 @@
 //   <Container width="hero">                 <!-- hero text block (896px) -->
 //   <Container width="reading">              <!-- long-form prose (700px) -->
 //   <Container as="section" class="py-section-y">
+//   <Container padded={false}>               <!-- no horizontal padding -->
 
 interface Props {
   /** Which max-width token to use. */
   width?: "reading" | "hero" | "content";
+  /** Whether to apply horizontal padding. Default: true. */
+  padded?: boolean;
   /** HTML element to render. Default: div. */
   as?: string;
   /** Extra classes appended after the layout classes. */
@@ -24,6 +27,7 @@ interface Props {
 
 const {
   width = "content",
+  padded = true,
   as: Tag = "div",
   class: className = "",
   ...rest
@@ -33,7 +37,7 @@ const widthClass = `max-w-${width}`;
 ---
 
 <Tag
-  class:list={[widthClass, "mx-auto px-container-x md:px-container-x-lg", className]}
+  class:list={[widthClass, "mx-auto", padded && "px-container-x md:px-container-x-lg", className]}
   {...rest}
 >
   <slot />

--- a/src/components/layout/Container.astro
+++ b/src/components/layout/Container.astro
@@ -1,0 +1,40 @@
+---
+// Container — max-width + horizontal padding wrapper.
+//
+// Consumes the --container-* tokens from the spacing spec. Every page-level
+// content block should be wrapped in a Container so width + padding are
+// governed by the design system, not ad-hoc utility classes.
+//
+// Usage:
+//   <Container>                              <!-- default: content (1280px) -->
+//   <Container width="hero">                 <!-- hero text block (896px) -->
+//   <Container width="reading">              <!-- long-form prose (700px) -->
+//   <Container as="section" class="py-section-y">
+
+interface Props {
+  /** Which max-width token to use. */
+  width?: "reading" | "hero" | "content";
+  /** HTML element to render. Default: div. */
+  as?: string;
+  /** Extra classes appended after the layout classes. */
+  class?: string;
+  /** Pass-through HTML attributes (id, aria-*, data-*, style, etc.) */
+  [key: string]: any;
+}
+
+const {
+  width = "content",
+  as: Tag = "div",
+  class: className = "",
+  ...rest
+} = Astro.props;
+
+const widthClass = `max-w-${width}`;
+---
+
+<Tag
+  class:list={[widthClass, "mx-auto px-container-x md:px-container-x-lg", className]}
+  {...rest}
+>
+  <slot />
+</Tag>

--- a/src/components/layout/Grid.astro
+++ b/src/components/layout/Grid.astro
@@ -1,0 +1,49 @@
+---
+// Grid — responsive column grid with token-based gap.
+//
+// Uses explicit breakpoint columns (not CSS auto-fit) because the editorial
+// layout is intentionally designed per breakpoint, not "fill available space."
+//
+// Usage:
+//   <Grid>                                     <!-- 1 / md:2 / lg:3, gap card-gap -->
+//   <Grid cols="1 sm:2 lg:4" gap="md">        <!-- category tiles -->
+//   <Grid cols="1 md:3" gap="lg" as="ul">     <!-- related articles -->
+
+interface Props {
+  /**
+   * Space-separated column spec. Each token is either a plain number (base)
+   * or a "breakpoint:number" pair. Examples:
+   *   "1 md:2 lg:3"  → grid-cols-1 md:grid-cols-2 lg:grid-cols-3
+   *   "1 md:3"       → grid-cols-1 md:grid-cols-3
+   */
+  cols?: string;
+  /** Spacing token name for the gap (maps to gap-{token}). */
+  gap?: string;
+  /** HTML element to render. Default: div. */
+  as?: string;
+  /** Extra classes appended after the layout classes. */
+  class?: string;
+  [key: string]: any;
+}
+
+const {
+  cols = "1 md:2 lg:3",
+  gap = "card-gap",
+  as: Tag = "div",
+  class: className = "",
+  ...rest
+} = Astro.props;
+
+// Parse "1 md:2 lg:3" → ["grid-cols-1", "md:grid-cols-2", "lg:grid-cols-3"]
+const colClasses = cols.split(/\s+/).map((token) => {
+  const [prefix, count] = token.includes(":") ? token.split(":") : ["", token];
+  return prefix ? `${prefix}:grid-cols-${count}` : `grid-cols-${count}`;
+});
+---
+
+<Tag
+  class:list={["grid", ...colClasses, `gap-${gap}`, className]}
+  {...rest}
+>
+  <slot />
+</Tag>

--- a/src/components/layout/Grid.astro
+++ b/src/components/layout/Grid.astro
@@ -35,7 +35,7 @@ const {
 } = Astro.props;
 
 // Parse "1 md:2 lg:3" → ["grid-cols-1", "md:grid-cols-2", "lg:grid-cols-3"]
-const colClasses = cols.split(/\s+/).map((token) => {
+const colClasses = cols.split(/\s+/).filter(Boolean).map((token) => {
   const [prefix, count] = token.includes(":") ? token.split(":") : ["", token];
   return prefix ? `${prefix}:grid-cols-${count}` : `grid-cols-${count}`;
 });

--- a/src/components/layout/Stack.astro
+++ b/src/components/layout/Stack.astro
@@ -1,0 +1,35 @@
+---
+// Stack — vertical rhythm with token-based gap.
+//
+// Renders a flex column with a gap drawn from the spacing scale. Replaces
+// scattered `space-y-*` and `flex flex-col gap-*` patterns in page templates.
+//
+// Usage:
+//   <Stack>                           <!-- default gap: stack (32px) -->
+//   <Stack gap="sm">                  <!-- tighter: 16px -->
+//   <Stack gap="section-y" as="ul">   <!-- section break, renders <ul> -->
+
+interface Props {
+  /** Spacing token name for the vertical gap (maps to gap-{token}). */
+  gap?: string;
+  /** HTML element to render. Default: div. */
+  as?: string;
+  /** Extra classes appended after the layout classes. */
+  class?: string;
+  [key: string]: any;
+}
+
+const {
+  gap = "stack",
+  as: Tag = "div",
+  class: className = "",
+  ...rest
+} = Astro.props;
+---
+
+<Tag
+  class:list={["flex flex-col", `gap-${gap}`, className]}
+  {...rest}
+>
+  <slot />
+</Tag>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,6 +4,9 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import CategoryTiles from "../components/CategoryTiles.astro";
 import Prose from "../components/Prose.astro";
 import SectionHead from "../components/SectionHead.astro";
+import Container from "../components/layout/Container.astro";
+import Stack from "../components/layout/Stack.astro";
+import Center from "../components/layout/Center.astro";
 
 const entry = await getEntry("about", "index");
 if (!entry) {
@@ -32,12 +35,12 @@ const { Content } = await render(entry);
     <div class="absolute inset-0 bg-gradient-to-t from-deep-charcoal via-transparent to-transparent"></div>
   </header>
 
-  <!-- Main content overlaps hero by --spacing-3xl (-mt: negative 3xl via calc) -->
-  <div class="max-w-content mx-auto px-container-x md:px-container-x-lg relative z-10 -mt-3xl">
+  <!-- Main content overlaps hero -->
+  <Container class="relative z-10 -mt-3xl">
 
     <!-- Page header: white card -->
     <div class="bg-white p-lg md:p-xl shadow-sm">
-      <div class="flex flex-col items-start gap-sm">
+      <Stack gap="sm" class="items-start">
         <!-- Headline -->
         <h1
           class="uppercase tracking-tighter max-w-hero text-deep-charcoal"
@@ -52,7 +55,7 @@ const { Content } = await render(entry);
         >
           {entry.data.tagline}
         </p>
-      </div>
+      </Stack>
     </div>
 
     <!-- Manifesto body — shared Prose component (no page-level scoped CSS) -->
@@ -64,11 +67,13 @@ const { Content } = await render(entry);
 
     <!-- What we cover — category tile grid -->
     <section class="py-section-y border-t border-outline-variant">
-      <SectionHead variant="editorial" class="mb-xl text-center">
-        What we cover
-      </SectionHead>
+      <Center class="mb-xl">
+        <SectionHead variant="editorial">
+          What we cover
+        </SectionHead>
+      </Center>
       <CategoryTiles />
     </section>
 
-  </div><!-- /max-w-content -->
+  </Container>
 </BaseLayout>

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -4,6 +4,10 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import Prose from "../../components/Prose.astro";
 import SectionHead from "../../components/SectionHead.astro";
 import { CATEGORIES, badgeStyle, type CategorySlug } from "../../lib/categories";
+import Container from "../../components/layout/Container.astro";
+import Stack from "../../components/layout/Stack.astro";
+import Cluster from "../../components/layout/Cluster.astro";
+import Grid from "../../components/layout/Grid.astro";
 
 export async function getStaticPaths() {
   // Exclude drafts — drafts must not be reachable at /articles/[slug] in
@@ -71,12 +75,12 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
     <div class="absolute inset-0 bg-gradient-to-t from-deep-charcoal via-transparent to-transparent"></div>
   </header>
 
-  <!-- Main content overlaps hero (negative margin = -1 × --spacing-3xl) -->
-  <div class="max-w-content mx-auto px-container-x md:px-container-x-lg relative z-10 -mt-3xl">
+  <!-- Main content overlaps hero -->
+  <Container class="relative z-10 -mt-3xl">
 
     <!-- Article header: white card -->
     <div class="bg-white p-lg md:p-xl shadow-sm">
-      <div class="flex flex-col items-start gap-sm">
+      <Stack gap="sm" class="items-start">
 
         <!-- Category pill — stamps in on page load via .motion-stamp-in -->
         <span
@@ -95,12 +99,12 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
         </h1>
 
         <!-- Date + tags row -->
-        <div class="flex flex-wrap items-center gap-sm text-on-surface-variant mt-sm" style="font-size: var(--text-caption)">
+        <Cluster gap="sm" align="center" class="text-on-surface-variant mt-sm" style="font-size: var(--text-caption)">
           <span style="font-family: var(--font-label)" class="italic">
             {dateStr}
           </span>
           {article.data.tags.length > 0 && (
-            <div class="flex flex-wrap gap-2xs">
+            <Cluster gap="2xs">
               {article.data.tags.map((tag) => (
                 <span
                   class="px-2xs py-3xs bg-surface-container-high uppercase font-bold tracking-tight text-on-surface-variant"
@@ -109,10 +113,10 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
                   {tag}
                 </span>
               ))}
-            </div>
+            </Cluster>
           )}
-        </div>
-      </div>
+        </Cluster>
+      </Stack>
 
       <!--
         Content version selector — UI scaffolding only. The Short Read /
@@ -156,7 +160,7 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
         <div class="mb-xl">
           <SectionHead variant="structural">More acts of defiance</SectionHead>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-lg">
+        <Grid cols="1 md:3" gap="lg">
           {related.map((rel) => {
             const tint = tintFor(rel.data.category);
             const relBadge = badgeStyle(rel.data.category);
@@ -197,10 +201,10 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
               </a>
             );
           })}
-        </div>
+        </Grid>
       </section>
     )}
 
-  </div><!-- /max-w-content -->
+  </Container>
 
 </BaseLayout>

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -3,6 +3,10 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ArticleCard from "../../components/ArticleCard.astro";
 import { CATEGORY_LIST } from "../../lib/categories";
+import Container from "../../components/layout/Container.astro";
+import Cluster from "../../components/layout/Cluster.astro";
+import Grid from "../../components/layout/Grid.astro";
+import Center from "../../components/layout/Center.astro";
 
 export async function getStaticPaths() {
   return CATEGORY_LIST.map((cat) => ({
@@ -35,7 +39,7 @@ const tags = [...tagSet].sort();
 >
   <!-- Page header: parchment-textured block with massive category title + tag filter row -->
   <header class="parchment-texture-category border-b border-outline-variant/30 pt-section-y pb-2xl px-container-x md:px-container-x-lg">
-    <div class="max-w-content mx-auto">
+    <Container width="content" class="!px-0">
       <h1
         class="uppercase tracking-tighter mb-md"
         style={`font-family: var(--font-headline); font-size: var(--text-display); line-height: 0.9; color:${category.accent}`}
@@ -55,7 +59,7 @@ const tags = [...tagSet].sort();
         properly conveyed as such to assistive technologies (the
         `disabled` attribute handles aria semantics by default).
       -->
-      <div class="flex flex-wrap gap-xs" role="group" aria-label="Filter by tag (coming soon)">
+      <Cluster gap="xs" role="group" aria-label="Filter by tag (coming soon)">
         <button
           type="button"
           disabled
@@ -76,14 +80,14 @@ const tags = [...tagSet].sort();
             {tag}
           </button>
         ))}
-      </div>
-    </div>
+      </Cluster>
+    </Container>
   </header>
 
   <!-- Article feed -->
-  <section class="max-w-content mx-auto px-container-x md:px-container-x-lg py-section-y">
+  <Container as="section" class="py-section-y">
     {articles.length === 0 ? (
-      <div class="py-section-y text-center">
+      <Center class="py-section-y">
         <p
           class="italic text-deep-charcoal/60"
           style="font-family: var(--font-label); font-size: var(--text-body-lg)"
@@ -93,23 +97,23 @@ const tags = [...tagSet].sort();
         <p class="mt-sm text-deep-charcoal/50" style="font-size: var(--text-body)">
           Content will flow here from dime.
         </p>
-      </div>
+      </Center>
     ) : (
       <>
-        <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-card-gap list-none p-0">
+        <Grid as="ul" class="list-none p-0">
           {articles.map((article, i) => (
             <li>
               <ArticleCard article={article} bordered variant={i} />
             </li>
           ))}
-        </ul>
+        </Grid>
 
         <!--
           Load more — UI scaffolding only. Pagination ships in a future
           ticket. Button is `disabled` until pagination is wired so it
           can't trap keyboard users in a dead-end interaction.
         -->
-        <div class="mt-section-y flex justify-center">
+        <Center class="mt-section-y">
           <button
             type="button"
             disabled
@@ -118,8 +122,8 @@ const tags = [...tagSet].sort();
           >
             Load More Archives
           </button>
-        </div>
+        </Center>
       </>
     )}
-  </section>
+  </Container>
 </BaseLayout>

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -39,7 +39,7 @@ const tags = [...tagSet].sort();
 >
   <!-- Page header: parchment-textured block with massive category title + tag filter row -->
   <header class="parchment-texture-category border-b border-outline-variant/30 pt-section-y pb-2xl px-container-x md:px-container-x-lg">
-    <Container width="content" class="!px-0">
+    <Container width="content" padded={false}>
       <h1
         class="uppercase tracking-tighter mb-md"
         style={`font-family: var(--font-headline); font-size: var(--text-display); line-height: 0.9; color:${category.accent}`}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,10 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import ArticleCard from "../components/ArticleCard.astro";
 import SectionHead from "../components/SectionHead.astro";
+import Container from "../components/layout/Container.astro";
+import Stack from "../components/layout/Stack.astro";
+import Grid from "../components/layout/Grid.astro";
+import Center from "../components/layout/Center.astro";
 
 const articles = (await getCollection("articles", ({ data }) => !data.draft))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
@@ -17,7 +21,7 @@ const articles = (await getCollection("articles", ({ data }) => !data.draft))
   <!-- Hero Section: cinematic. Extends behind fixed header (h = 768 + 64) so no parchment gap shows. -->
   <section class="relative w-full h-[832px] min-h-[564px] overflow-hidden bg-black">
     <div class="absolute inset-0 hero-gradient flex flex-col justify-end px-container-x md:px-container-x-lg pb-hero-pb">
-      <div class="max-w-hero space-y-stack">
+      <Stack gap="stack" class="max-w-hero items-start">
         <span
           class="motion-stamp-in inline-block bg-tertiary text-white px-sm py-3xs rounded-full font-bold uppercase tracking-widest"
           style="font-family: var(--font-headline); font-size: var(--text-caption)"
@@ -49,30 +53,30 @@ const articles = (await getCollection("articles", ({ data }) => !data.draft))
             >arrow_forward</span>
           </a>
         </div>
-      </div>
+      </Stack>
     </div>
   </section>
 
   <!-- Recent Articles Feed -->
-  <section class="py-section-y px-container-x md:px-container-x-lg">
-    <div class="max-w-content mx-auto">
-      <div class="mb-xl border-b-4 border-primary pb-sm">
-        <SectionHead variant="editorial">Recent stories</SectionHead>
-      </div>
+  <Container as="section" class="py-section-y">
+    <div class="mb-xl border-b-4 border-primary pb-sm">
+      <SectionHead variant="editorial">Recent stories</SectionHead>
+    </div>
 
-      {articles.length === 0 ? (
-        <p class="text-center text-deep-charcoal/50 py-2xl italic" style="font-family: var(--font-label)">
+    {articles.length === 0 ? (
+      <Center class="py-2xl">
+        <p class="text-deep-charcoal/50 italic" style="font-family: var(--font-label)">
           Content will flow here from dime.
         </p>
-      ) : (
-        <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-card-gap list-none p-0">
-          {articles.map((article) => (
-            <li>
-              <ArticleCard article={article} />
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  </section>
+      </Center>
+    ) : (
+      <Grid as="ul" class="list-none p-0">
+        {articles.map((article) => (
+          <li>
+            <ArticleCard article={article} />
+          </li>
+        ))}
+      </Grid>
+    )}
+  </Container>
 </BaseLayout>


### PR DESCRIPTION
## Summary

- Adds 5 composable layout primitives in `src/components/layout/`: `Container`, `Stack`, `Cluster`, `Grid`, `Center`
- Refactors all page templates and shared components to use primitives — eliminates ad-hoc `max-w-*/mx-auto/px-*`, `space-y-*`, `flex flex-wrap gap-*`, and `grid grid-cols-*` patterns
- Adds `docs/specs/layout.md` with full primitive API, usage rules, composition examples, and forbidden patterns
- Updates `CLAUDE.md` with layout primitives quick-reference

## Closes

Closes #9

## Test plan

- [ ] `bun run build` passes (8 routes, no type errors)
- [ ] Home: hero section renders correctly; Manifesto badge is intrinsically sized (not full-width)
- [ ] Home: article grid renders at 1/2/3 cols across breakpoints
- [ ] About: page header and category tiles render correctly
- [ ] Category: article grid and tag filter cluster render correctly
- [ ] Article: article header, date+tags cluster, and related articles grid render correctly
- [ ] Footer: nav links wrap correctly on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)