### PR TITLE
Define button & link system

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -1,0 +1,78 @@
+---
+// Button — single CTA component for Acts of Defiance.
+//
+// Renders <a> when href is provided, <button> otherwise.
+// All four variants consume the motion tokens from global.css:
+//   - primary, secondary, ghost: .aod-brand-btn (letterpress) + .aod-focus-ring
+//   - link: .aod-brand-link (underline sweep) + .aod-focus-ring
+//
+// Usage:
+//   <Button href="/about">Read the Manifesto</Button>
+//   <Button variant="secondary" size="sm">Subscribe</Button>
+//   <Button variant="ghost" type="button">Cancel</Button>
+//   <Button variant="link" href="/about">inline link text</Button>
+
+interface Props {
+  /** Visual style. Default: "primary". */
+  variant?: "primary" | "secondary" | "ghost" | "link";
+  /** Size. Default: "md". */
+  size?: "sm" | "md" | "lg";
+  /** When present, renders an <a> tag. */
+  href?: string;
+  /** Disabled state — only meaningful on <button>. */
+  disabled?: boolean;
+  /** Extra classes appended last. */
+  class?: string;
+  /** Pass-through attributes (type, aria-*, data-*, etc.) */
+  [key: string]: any;
+}
+
+const {
+  variant = "primary",
+  size = "md",
+  href,
+  disabled = false,
+  class: className = "",
+  ...rest
+} = Astro.props;
+
+const Tag = href ? "a" : "button";
+
+// Size → padding + font-size (token-based, no raw px)
+const sizeClasses: Record<string, string> = {
+  sm: "px-sm py-3xs",
+  md: "px-lg py-sm",
+  lg: "px-xl py-md",
+};
+const fontSizes: Record<string, string> = {
+  sm: "var(--text-caption)",
+  md: "var(--text-caption)",
+  lg: "var(--text-body)",
+};
+
+const isLink = variant === "link";
+
+// Base layout classes shared by all non-link variants
+const baseClasses = isLink
+  ? "aod-brand-link aod-focus-ring rounded-sm"
+  : [
+      "aod-brand-btn aod-focus-ring",
+      "inline-flex items-center gap-2xs",
+      "rounded-lg font-black uppercase tracking-widest",
+      "select-none",
+      sizeClasses[size],
+      `aod-btn-${variant}`,
+      disabled ? "pointer-events-none opacity-50" : "",
+    ].join(" ");
+---
+
+<Tag
+  href={href}
+  disabled={Tag === "button" && disabled ? true : undefined}
+  aria-disabled={Tag === "a" && disabled ? "true" : undefined}
+  class:list={[baseClasses, className]}
+  style={`font-family: var(--font-headline); font-size: ${fontSizes[size]}`}
+  {...rest}
+>
+  <slot />
+</Tag>

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -19,7 +19,7 @@ interface Props {
   size?: "sm" | "md" | "lg";
   /** When present, renders an <a> tag. */
   href?: string;
-  /** Disabled state — only meaningful on <button>. */
+  /** Disabled state — sets aria-disabled on <a>, disabled on <button>, and removes from tab order. */
   disabled?: boolean;
   /** Extra classes appended last. */
   class?: string;
@@ -52,7 +52,6 @@ const fontSizes: Record<string, string> = {
 
 const isLink = variant === "link";
 
-// Base layout classes shared by all non-link variants
 const baseClasses = isLink
   ? "aod-brand-link aod-focus-ring rounded-sm"
   : [
@@ -62,15 +61,16 @@ const baseClasses = isLink
       "select-none",
       sizeClasses[size],
       `aod-btn-${variant}`,
-      disabled ? "pointer-events-none opacity-50" : "",
     ].join(" ");
 ---
 
 <Tag
   href={href}
+  type={Tag === "button" ? "button" : undefined}
   disabled={Tag === "button" && disabled ? true : undefined}
   aria-disabled={Tag === "a" && disabled ? "true" : undefined}
-  class:list={[baseClasses, className]}
+  tabindex={Tag === "a" && disabled ? -1 : undefined}
+  class:list={[baseClasses, disabled && "pointer-events-none", className]}
   style={`font-family: var(--font-headline); font-size: ${fontSizes[size]}`}
   {...rest}
 >

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import Container from "../components/layout/Container.astro";
 import Stack from "../components/layout/Stack.astro";
 import Grid from "../components/layout/Grid.astro";
 import Center from "../components/layout/Center.astro";
+import Button from "../components/Button.astro";
 
 const articles = (await getCollection("articles", ({ data }) => !data.draft))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
@@ -40,18 +41,14 @@ const articles = (await getCollection("articles", ({ data }) => !data.draft))
           a form of resistance.
         </p>
         <div class="pt-sm">
-          <a
-            href="/about"
-            class="aod-brand-btn aod-focus-ring inline-flex items-center gap-2xs bg-primary text-white px-lg py-sm rounded-lg font-black uppercase tracking-widest hover:bg-opacity-90 group"
-            style="font-family: var(--font-headline); font-size: var(--text-caption)"
-          >
+          <Button href="/about" variant="primary" class="group">
             Read the Manifesto
             <span
               class="material-symbols-outlined group-hover:translate-x-1"
               style="transition: transform var(--duration-arrive) var(--ease-manifesto)"
               aria-hidden="true"
             >arrow_forward</span>
-          </a>
+          </Button>
         </div>
       </Stack>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -379,11 +379,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 .aod-btn-primary:hover {
   background-color: color-mix(in srgb, var(--color-revolutionary-red) 85%, black);
-  transition-property: background-color;
-  transition-duration: var(--duration-quick);
-  transition-timing-function: var(--ease-manifesto);
 }
-.aod-btn-primary:disabled {
+.aod-btn-primary:disabled,
+.aod-btn-primary[aria-disabled="true"] {
   background-color: color-mix(in srgb, var(--color-revolutionary-red) 40%, white);
   cursor: not-allowed;
 }
@@ -396,11 +394,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 .aod-btn-secondary:hover {
   background-color: color-mix(in srgb, var(--color-warm-gold) 85%, black);
-  transition-property: background-color;
-  transition-duration: var(--duration-quick);
-  transition-timing-function: var(--ease-manifesto);
 }
-.aod-btn-secondary:disabled {
+.aod-btn-secondary:disabled,
+.aod-btn-secondary[aria-disabled="true"] {
   background-color: color-mix(in srgb, var(--color-warm-gold) 40%, white);
   cursor: not-allowed;
 }
@@ -414,11 +410,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 .aod-btn-ghost:hover {
   background-color: color-mix(in srgb, var(--color-deep-charcoal) 8%, transparent);
-  transition-property: background-color;
-  transition-duration: var(--duration-quick);
-  transition-timing-function: var(--ease-manifesto);
 }
-.aod-btn-ghost:disabled {
+.aod-btn-ghost:disabled,
+.aod-btn-ghost[aria-disabled="true"] {
   border-color: color-mix(in srgb, var(--color-deep-charcoal) 30%, transparent);
   color: color-mix(in srgb, var(--color-deep-charcoal) 30%, transparent);
   cursor: not-allowed;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -364,6 +364,71 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* ============================================================
+ * Button variants — consumed by src/components/Button.astro.
+ *
+ * Base motion comes from .aod-brand-btn (letterpress press) and
+ * .aod-focus-ring (focus pulse), which Button always applies.
+ * These classes handle only color + border identity per variant.
+ * ============================================================ */
+
+/* primary — revolutionary red, white text */
+.aod-btn-primary {
+  background-color: var(--color-revolutionary-red);
+  color: var(--color-white);
+  border: 2px solid transparent;
+}
+.aod-btn-primary:hover {
+  background-color: color-mix(in srgb, var(--color-revolutionary-red) 85%, black);
+  transition-property: background-color;
+  transition-duration: var(--duration-quick);
+  transition-timing-function: var(--ease-manifesto);
+}
+.aod-btn-primary:disabled {
+  background-color: color-mix(in srgb, var(--color-revolutionary-red) 40%, white);
+  cursor: not-allowed;
+}
+
+/* secondary — warm gold, deep-charcoal text */
+.aod-btn-secondary {
+  background-color: var(--color-warm-gold);
+  color: var(--color-deep-charcoal);
+  border: 2px solid transparent;
+}
+.aod-btn-secondary:hover {
+  background-color: color-mix(in srgb, var(--color-warm-gold) 85%, black);
+  transition-property: background-color;
+  transition-duration: var(--duration-quick);
+  transition-timing-function: var(--ease-manifesto);
+}
+.aod-btn-secondary:disabled {
+  background-color: color-mix(in srgb, var(--color-warm-gold) 40%, white);
+  cursor: not-allowed;
+}
+
+/* ghost — transparent with deep-charcoal border; press plate uses border color */
+.aod-btn-ghost {
+  background-color: transparent;
+  color: var(--color-deep-charcoal);
+  border: 2px solid var(--color-deep-charcoal);
+  box-shadow: 0 2px 0 0 color-mix(in srgb, var(--color-deep-charcoal) 50%, transparent);
+}
+.aod-btn-ghost:hover {
+  background-color: color-mix(in srgb, var(--color-deep-charcoal) 8%, transparent);
+  transition-property: background-color;
+  transition-duration: var(--duration-quick);
+  transition-timing-function: var(--ease-manifesto);
+}
+.aod-btn-ghost:disabled {
+  border-color: color-mix(in srgb, var(--color-deep-charcoal) 30%, transparent);
+  color: color-mix(in srgb, var(--color-deep-charcoal) 30%, transparent);
+  cursor: not-allowed;
+}
+
+/* link — text only, uses aod-brand-link underline sweep (no letterpress).
+ * Applied via the component's class list; no separate CSS class needed here.
+ * Documented for completeness. */
+
+/* ============================================================
  * Reduced motion — global collapse.
  * Every transition + animation duration drops to 0.01ms (not zero so
  * transitionend / animationend still fire). Opacity transitions are


### PR DESCRIPTION
## Summary

- Adds `<Button>` component (`src/components/Button.astro`) — renders `<a>` or `<button>` based on `href`; four variants (`primary`, `secondary`, `ghost`, `link`); three sizes (`sm`, `md`, `lg`) via spacing + type tokens; `disabled` state; full attr pass-through
- Adds CSS variant classes (`aod-btn-primary`, `aod-btn-secondary`, `aod-btn-ghost`) to `global.css`; all motion via existing `aod-brand-btn` + `aod-focus-ring` helpers
- Refactors hero CTA in `index.astro` from raw `<a class="...">` to `<Button variant="primary">`
- Spec doc (`docs/specs/buttons.md`) committed to dime-ops

## Closes

Closes #10

## Test plan

- [ ] `bun run build` passes (8 routes)
- [ ] Home hero: "Read the Manifesto" button renders red, letterpress press on click, focus pulse on Tab
- [ ] Button renders as `<a>` when `href` provided, `<button>` otherwise
- [ ] All four variants and three sizes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)