### PR TITLE
Add custom SVG icons and tile hover animation to category grid

### DIFF
--- a/src/components/CategoryIcon.astro
+++ b/src/components/CategoryIcon.astro
@@ -36,8 +36,8 @@ const { slug, size = 40, class: className = "" } = Astro.props;
     <rect x="32" y="24" width="7" height="57" rx="3" />
     <!-- Right notehead (higher pitch — ascending) -->
     <ellipse cx="63" cy="59" rx="17" ry="11" transform="rotate(-25, 63, 59)" />
-    <!-- Right stem — same height as left stem -->
-    <rect x="76" y="4" width="7" height="57" rx="3" />
+    <!-- Right stem — same height as left stem; y=7 keeps top behind beam -->
+    <rect x="76" y="7" width="7" height="54" rx="3" />
     <!-- Beam: angled ascending left→right, covers stem tops -->
     <polygon points="32,24 83,4 83,14 32,34" />
   </svg>

--- a/src/components/CategoryIcon.astro
+++ b/src/components/CategoryIcon.astro
@@ -1,0 +1,122 @@
+---
+// Custom SVG icons for each category tile.
+// All icons use currentColor so they inherit white from the parent tile.
+// Rendered at two sizes: ghost (~112px decorative) and front (~40px prominent).
+import type { CategorySlug } from "../lib/categories";
+
+interface Props {
+  slug: CategorySlug;
+  /** Width/height in px — applied directly on the SVG element. */
+  size?: number;
+  class?: string;
+}
+
+const { slug, size = 40, class: className = "" } = Astro.props;
+---
+
+{slug === "artists" ? (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 100 100"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    class={className}
+  >
+    <!--
+      Ascending beamed eighth notes: left notehead lower, right notehead higher,
+      stems up, thick beam angled from lower-left to upper-right.
+      Stems are equal height rects; each rect bottom extends into the notehead
+      ellipse so the same fill color hides the junction — no visible seam.
+    -->
+    <!-- Left notehead (lower pitch) -->
+    <ellipse cx="19" cy="79" rx="17" ry="11" transform="rotate(-25, 19, 79)" />
+    <!-- Left stem — bottom buried inside notehead ellipse, same height as right -->
+    <rect x="32" y="24" width="7" height="57" rx="3" />
+    <!-- Right notehead (higher pitch — ascending) -->
+    <ellipse cx="63" cy="59" rx="17" ry="11" transform="rotate(-25, 63, 59)" />
+    <!-- Right stem — same height as left stem -->
+    <rect x="76" y="4" width="7" height="57" rx="3" />
+    <!-- Beam: angled ascending left→right, covers stem tops -->
+    <polygon points="32,24 83,4 83,14 32,34" />
+  </svg>
+) : slug === "movements" ? (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 100 100"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    class={className}
+  >
+    <!--
+      Three bold parallel diagonal strokes, all sweeping upper-right —
+      multiple entities moving in the same direction.
+      Direction comes from the shape itself, not arrangement.
+      Rounded caps keep it organic rather than military.
+    -->
+    <line x1="8"  y1="82" x2="38" y2="20" stroke="currentColor" stroke-width="13" stroke-linecap="round" />
+    <line x1="34" y1="90" x2="64" y2="28" stroke="currentColor" stroke-width="13" stroke-linecap="round" />
+    <line x1="60" y1="90" x2="90" y2="28" stroke="currentColor" stroke-width="13" stroke-linecap="round" />
+  </svg>
+) : slug === "organizations" ? (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 100 100"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    class={className}
+  >
+    <!--
+      Asymmetric network of 4 nodes — structure, collaboration, deliberate arrangement.
+      Node sizes vary (hub vs. leaf) to break the geometric regularity.
+    -->
+    <!-- Edges first so nodes paint over them -->
+    <line x1="28" y1="22" x2="76" y2="30" stroke="currentColor" stroke-width="5" stroke-linecap="round" />
+    <line x1="28" y1="22" x2="16" y2="74" stroke="currentColor" stroke-width="5" stroke-linecap="round" />
+    <line x1="76" y1="30" x2="82" y2="78" stroke="currentColor" stroke-width="5" stroke-linecap="round" />
+    <line x1="76" y1="30" x2="16" y2="74" stroke="currentColor" stroke-width="5" stroke-linecap="round" />
+    <!-- Nodes: different radii signal hierarchy -->
+    <circle cx="28" cy="22" r="14" fill="currentColor" />
+    <circle cx="76" cy="30" r="11" fill="currentColor" />
+    <circle cx="16" cy="74" r="8"  fill="currentColor" />
+    <circle cx="82" cy="78" r="10" fill="currentColor" />
+  </svg>
+) : (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 100 100"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    class={className}
+  >
+    <!--
+      Three human silhouettes at different heights and proportions.
+      Large heads (heads are the primary legibility signal), simple torso + legs.
+      Left: medium, broader. Center: tallest, slender. Right: shorter.
+    -->
+    <!-- Left person -->
+    <circle cx="20" cy="34" r="13" />
+    <rect x="9"  y="47" width="22" height="28" rx="8" />
+    <rect x="8"  y="68" width="10" height="22" rx="4" />
+    <rect x="22" y="68" width="10" height="22" rx="4" />
+
+    <!-- Center person (tallest) -->
+    <circle cx="50" cy="20" r="15" />
+    <rect x="37" y="35" width="26" height="30" rx="9" />
+    <rect x="36" y="58" width="11" height="26" rx="5" />
+    <rect x="53" y="58" width="11" height="26" rx="5" />
+
+    <!-- Right person (shorter, stockier) -->
+    <circle cx="80" cy="36" r="12" />
+    <rect x="69" y="48" width="22" height="24" rx="7" />
+    <rect x="68" y="65" width="10" height="22" rx="4" />
+    <rect x="82" y="65" width="10" height="22" rx="4" />
+  </svg>
+)}

--- a/src/components/CategoryTiles.astro
+++ b/src/components/CategoryTiles.astro
@@ -20,8 +20,7 @@ import CategoryIcon from "./CategoryIcon.astro";
         Scales up slightly on hover alongside the opacity lift.
       -->
       <div
-        class="absolute -right-lg -top-lg opacity-20 group-hover:opacity-30 group-hover:scale-125"
-        style="transition: opacity var(--duration-quick) var(--ease-manifesto), transform var(--duration-declare) var(--ease-defiant)"
+        class="category-tile__ghost absolute -right-lg -top-lg opacity-20 group-hover:opacity-30 group-hover:scale-125"
         aria-hidden="true"
       >
         <CategoryIcon slug={cat.slug} size={112} />
@@ -41,3 +40,11 @@ import CategoryIcon from "./CategoryIcon.astro";
     </a>
   ))}
 </div>
+
+<style>
+  .category-tile__ghost {
+    transition:
+      opacity var(--duration-quick) var(--ease-manifesto),
+      transform var(--duration-declare) var(--ease-defiant);
+  }
+</style>

--- a/src/components/CategoryTiles.astro
+++ b/src/components/CategoryTiles.astro
@@ -1,50 +1,43 @@
 ---
-// Four-up category tile grid lifted from ../art/comps/v3/home.html.
-// Each tile: solid accent bg, ghost icon in upper-right, smaller icon
-// upper-left, category name at the bottom. Used on the about page
-// (and intended for the home page newsletter section eventually).
+// Four-up category tile grid.
+// Uses literal grid classes (not <Grid>) so Tailwind's JIT scanner
+// can detect grid-cols-2 / lg:grid-cols-4 as static strings.
+// Tiles are aspect-square so they stay visually square at all breakpoints.
 import { CATEGORY_LIST } from "../lib/categories";
-import Grid from "./layout/Grid.astro";
+import CategoryIcon from "./CategoryIcon.astro";
 ---
 
-<Grid cols="1 sm:2 lg:4" gap="md">
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-md">
   {CATEGORY_LIST.map((cat) => (
     <a
       href={`/categories/${cat.slug}`}
-      class="aod-brand-card aod-focus-ring p-lg px-md rounded-lg h-64 flex flex-col justify-between group cursor-pointer shadow-md relative overflow-hidden"
+      class="aod-brand-card aod-focus-ring aspect-square p-lg px-md rounded-lg flex flex-col justify-between group cursor-pointer shadow-md relative overflow-hidden"
       style={`background:${cat.accent}`}
       aria-label={`Browse ${cat.name}`}
     >
-      <!-- Ghost icon — large, decorative, in the corner.
-           The -right-lg/-top-lg offset pulls the icon partly off-canvas
-           so the clipped silhouette reads as decoration. -->
+      <!--
+        Ghost icon — large, decorative, partially clipped off the upper-right corner.
+        Scales up slightly on hover alongside the opacity lift.
+      -->
       <div
-        class="absolute -right-lg -top-lg opacity-20 group-hover:opacity-30"
-        style="transition: opacity var(--duration-quick) var(--ease-manifesto)"
+        class="absolute -right-lg -top-lg opacity-20 group-hover:opacity-30 group-hover:scale-125"
+        style="transition: opacity var(--duration-quick) var(--ease-manifesto), transform var(--duration-declare) var(--ease-defiant)"
         aria-hidden="true"
       >
-        <span
-          class="material-symbols-outlined text-[120px]"
-          style="font-variation-settings: 'FILL' 1;"
-        >
-          {cat.icon}
-        </span>
+        <CategoryIcon slug={cat.slug} size={112} />
       </div>
+
       <!-- Front icon -->
-      <div class="relative z-10" aria-hidden="true">
-        <span
-          class="material-symbols-outlined text-4xl text-white block"
-          style="font-variation-settings: 'FILL' 1;"
-        >
-          {cat.icon}
-        </span>
+      <div class="relative z-10">
+        <CategoryIcon slug={cat.slug} size={40} />
       </div>
+
       <h3
-        class="font-bold text-white uppercase tracking-tight leading-none relative z-10 truncate"
+        class="aod-brand-card__title font-bold text-white uppercase tracking-tight leading-none relative z-10 truncate"
         style="font-family: var(--font-headline); font-size: var(--text-body-lg)"
       >
         {cat.name}
       </h3>
     </a>
   ))}
-</Grid>
+</div>

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -13,8 +13,6 @@ export interface Category {
   accent: string;
   /** Foreground color to pair with the accent for accessible contrast. */
   accentText: string;
-  /** Material Symbols Outlined icon name used by the CategoryTiles grid. */
-  icon: string;
 }
 
 export const CATEGORIES: Record<CategorySlug, Category> = {
@@ -24,7 +22,6 @@ export const CATEGORIES: Record<CategorySlug, Category> = {
     tagline: "Art is a hammer to shape reality.",
     accent: "#795900",
     accentText: "#ffffff",
-    icon: "brush",
   },
   movements: {
     slug: "movements",
@@ -32,7 +29,6 @@ export const CATEGORIES: Record<CategorySlug, Category> = {
     tagline: "Every movement started with someone who refused.",
     accent: "#c23b22",
     accentText: "#ffffff",
-    icon: "groups",
   },
   organizations: {
     slug: "organizations",
@@ -40,7 +36,6 @@ export const CATEGORIES: Record<CategorySlug, Category> = {
     tagline: "Structure is how survival becomes strategy.",
     accent: "#2a7b88",
     accentText: "#ffffff",
-    icon: "account_balance",
   },
   people: {
     slug: "people",
@@ -48,7 +43,6 @@ export const CATEGORIES: Record<CategorySlug, Category> = {
     tagline: "Memory is itself an act of resistance.",
     accent: "#795548",
     accentText: "#ffffff",
-    icon: "person",
   },
 };
 


### PR DESCRIPTION
## Summary
- Hand-crafted SVG icon per category (Artists, Movements, Organizations, People) — no icon library dependency
- Fixed tile grid layout: `<Grid>` primitive was invisble to Tailwind JIT, replaced with literal classes
- Tiles are `aspect-square` instead of fixed height
- Three-layer hover animation using brand motion tokens: risograph headline offset → card lift → ghost icon defiant overshoot

Closes #1

## Verification
```bash
bun run dev
# Home page — verify all four tiles render with icons and hover correctly
```

## Checklist
- [x] `bun run build` succeeds without errors
- [x] Visually verified at localhost:4321
- [x] Responsive design verified (2-col mobile, 4-col desktop)
- [x] Motion uses brand tokens only (no Tailwind defaults, no hardcoded ms)
- [x] No secrets committed