### PR TITLE
Wire content pipeline and build article page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@astrojs/svelte": "^8.0.4",
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.1.3",
+        "marked": "^18.0.0",
         "svelte": "^5.55.1",
         "tailwindcss": "^4.2.2",
         "typescript": "^5.9.3",
@@ -486,6 +487,8 @@
     "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "marked": ["marked@18.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA=="],
 
     "mdast-util-definitions": ["mdast-util-definitions@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ=="],
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "node": ">=22.12.0"
   },
   "scripts": {
-    "dev": "astro dev",
-    "build": "astro build",
+    "sync": "bun scripts/copy-art.ts",
+    "dev": "bun run sync && astro dev",
+    "build": "bun run sync && astro build",
     "preview": "astro preview",
     "check": "astro check",
     "astro": "astro"
@@ -16,6 +17,7 @@
     "@astrojs/svelte": "^8.0.4",
     "@tailwindcss/vite": "^4.2.2",
     "astro": "^6.1.3",
+    "marked": "^18.0.0",
     "svelte": "^5.55.1",
     "tailwindcss": "^4.2.2",
     "typescript": "^5.9.3"

--- a/scripts/copy-art.ts
+++ b/scripts/copy-art.ts
@@ -1,0 +1,30 @@
+/**
+ * Sync images from the art/ sibling repo into public/images/articles/
+ * so Astro can serve them at /images/articles/{filename}.
+ *
+ * Run via: bun scripts/copy-art.ts
+ * Invoked automatically by `bun run build` and `bun run dev`.
+ *
+ * In production the AstroAdapter handles image placement; this script
+ * is for local development and CI builds only.
+ */
+import { readdirSync, copyFileSync, mkdirSync } from "fs";
+import { join, extname } from "path";
+
+const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".svg", ".webp", ".gif", ".avif"]);
+
+const srcDir = join(import.meta.dir, "../../art");
+const destDir = join(import.meta.dir, "../public/images/articles");
+
+mkdirSync(destDir, { recursive: true });
+
+const files = readdirSync(srcDir);
+let copied = 0;
+for (const file of files) {
+  if (IMAGE_EXTS.has(extname(file).toLowerCase())) {
+    copyFileSync(join(srcDir, file), join(destDir, file));
+    copied++;
+  }
+}
+
+console.log(`[copy-art] Synced ${copied} image(s): art/ → public/images/articles/`);

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -35,7 +35,7 @@ const placeholderBg =
 
 <a
   href={`/articles/${article.id}`}
-  class="aod-brand-card aod-focus-ring flex flex-col gap-md group cursor-pointer rounded-lg bg-white"
+  class="aod-brand-card aod-focus-ring flex flex-col group cursor-pointer rounded-lg bg-white"
 >
   <div
     class:list={[
@@ -51,7 +51,7 @@ const placeholderBg =
       <img
         src={`/images/articles/${article.data.images.hero}`}
         alt={article.data.title}
-        class="aod-brand-card__image w-full h-full object-cover mix-blend-multiply opacity-90"
+        class="aod-brand-card__image w-full h-full object-cover"
       />
     ) : (
       <div class="w-full h-full flex items-center justify-center">
@@ -72,9 +72,10 @@ const placeholderBg =
       </span>
     </div>
   </div>
-  <Stack gap="xs" class="px-md pb-md">
+  <div style="height: 10rem; overflow: hidden">
+  <Stack gap="xs" class="px-md pb-md pt-sm">
     <h3
-      class="aod-brand-card__title uppercase tracking-tight text-deep-charcoal"
+      class="aod-brand-card__title line-clamp-2 uppercase tracking-tight text-deep-charcoal"
       style="font-family: var(--font-headline); font-size: var(--text-h4); line-height: 1.05"
     >
       {article.data.title}
@@ -85,17 +86,6 @@ const placeholderBg =
     >
       {article.data.description}
     </p>
-    {article.data.tags.length > 0 && (
-      <Cluster gap="2xs" class="pt-3xs">
-        {article.data.tags.map((tag) => (
-          <span
-            class="font-bold uppercase tracking-tighter text-deep-charcoal/60"
-            style="font-size: var(--text-caption)"
-          >
-            #{tag}
-          </span>
-        ))}
-      </Cluster>
-    )}
   </Stack>
+  </div>
 </a>

--- a/src/components/ArticleContent.svelte
+++ b/src/components/ArticleContent.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  // Svelte 5 island — article content tab switcher.
+  // "The Story" (TLDR) is the default; "Deep Dive" (Research) is the full article.
+  // Both sections are pre-rendered server-side and passed as HTML strings.
+  let { storyHtml, deepHtml }: { storyHtml: string; deepHtml: string } = $props();
+  let active = $state<'story' | 'deep'>('story');
+</script>
+
+<!-- Tab selector -->
+<div class="flex gap-sm mt-xl border-t border-outline-variant pt-lg">
+  <!-- The Story tab -->
+  <button
+    type="button"
+    onclick={() => active = 'story'}
+    style="flex:1; text-align:left; padding: var(--spacing-md); cursor:pointer; background:{active !== 'story' ? 'white' : 'var(--color-surface-container)'}; {active !== 'story' ? 'border-bottom:4px solid var(--color-primary-container); box-shadow:0 4px 8px -2px rgba(0,0,0,0.12)' : ''}"
+  >
+    <div
+      style="font-family:var(--font-headline); font-size:var(--text-caption); text-transform:uppercase; font-weight:700; letter-spacing:0.1em; margin-bottom:var(--spacing-2xs); color:{active === 'story' ? 'var(--color-primary-md)' : 'inherit'}; opacity:{active === 'story' ? '1' : '0.6'}"
+    >
+      Short Read
+    </div>
+    <div style="font-family:var(--font-headline); font-size:var(--text-body-lg); font-weight:700; line-height:1.2">
+      The Story
+    </div>
+    <div
+      style="height:4px; margin-top:var(--spacing-sm); background:var(--color-primary-container); transition:width var(--duration-arrive) var(--ease-manifesto); width:{active === 'story' ? '100%' : '0'}"
+    ></div>
+  </button>
+
+  <!-- Deep Dive tab -->
+  <button
+    type="button"
+    onclick={() => active = 'deep'}
+    style="flex:1; text-align:left; padding: var(--spacing-md); cursor:pointer; background:{active !== 'deep' ? 'white' : 'var(--color-surface-container)'}; {active !== 'deep' ? 'border-bottom:4px solid var(--color-primary-container); box-shadow:0 4px 8px -2px rgba(0,0,0,0.12)' : ''}"
+  >
+    <div
+      style="font-family:var(--font-headline); font-size:var(--text-caption); text-transform:uppercase; font-weight:700; letter-spacing:0.1em; margin-bottom:var(--spacing-2xs); color:{active === 'deep' ? 'var(--color-primary-md)' : 'inherit'}; opacity:{active === 'deep' ? '1' : '0.6'}"
+    >
+      Full Research
+    </div>
+    <div style="font-family:var(--font-headline); font-size:var(--text-body-lg); font-weight:700; line-height:1.2">
+      Deep Dive
+    </div>
+    <div
+      style="height:4px; margin-top:var(--spacing-sm); background:var(--color-primary-container); transition:width var(--duration-arrive) var(--ease-manifesto); width:{active === 'deep' ? '100%' : '0'}"
+    ></div>
+  </button>
+</div>
+
+<!-- Content -->
+<article style="background:var(--color-parchment); padding: var(--spacing-2xl) var(--spacing-container-x)">
+  <div class="prose mx-auto max-w-reading">
+    {@html active === 'story' ? storyHtml : deepHtml}
+  </div>
+</article>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,16 +2,31 @@ import { defineCollection, z } from "astro:content";
 import { glob } from "astro/loaders";
 
 // Acts of Defiance article content collection.
-// Articles are produced by dime and placed in src/content/articles/ by the AstroAdapter.
-// See docs/design/aod-site-architecture.md for schema rationale.
+// In production, articles flow from dime via the AstroAdapter.
+// For local dev and build, content is read directly from the compendium/ repo
+// (one level above this repo). README.md is excluded via the [!R]*.md pattern.
 
 const articles = defineCollection({
-  loader: glob({ pattern: "**/*.md", base: "./src/content/articles" }),
+  loader: glob({ pattern: "[!R]*.md", base: "../compendium" }),
   schema: z.object({
     title: z.string(),
-    description: z.string(),
-    date: z.coerce.date(),
-    category: z.enum(["artists", "movements", "organizations", "people"]),
+    // description may be absent in compendium drafts — empty string is a safe fallback.
+    description: z.string().default(""),
+    // Compendium dates may be strings like "1920-present" rather than ISO dates.
+    // Extract the first 4-digit year and use Jan 1 of that year.
+    date: z
+      .string()
+      .or(z.coerce.date())
+      .transform((val) => {
+        if (val instanceof Date) return val;
+        const match = String(val).match(/(\d{4})/);
+        return match ? new Date(parseInt(match[1]), 0, 1) : new Date();
+      }),
+    // Articles without a category build fine but won't appear on category pages
+    // until category is added to compendium frontmatter.
+    category: z
+      .enum(["artists", "movements", "organizations", "people"])
+      .optional(),
     tags: z.array(z.string()).default([]),
     images: z
       .object({

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -1,7 +1,8 @@
 ---
 import { getCollection, render } from "astro:content";
+import { marked } from "marked";
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import Prose from "../../components/Prose.astro";
+import ArticleContent from "../../components/ArticleContent.svelte";
 import SectionHead from "../../components/SectionHead.astro";
 import { CATEGORIES, badgeStyle, type CategorySlug } from "../../lib/categories";
 import Container from "../../components/layout/Container.astro";
@@ -22,7 +23,7 @@ export async function getStaticPaths() {
     props: {
       article,
       related: articles
-        .filter((a) => a.id !== article.id && a.data.category === article.data.category)
+        .filter((a) => a.id !== article.id && a.data.category !== undefined && a.data.category === article.data.category)
         .slice(0, 3),
     },
   }));
@@ -31,7 +32,23 @@ export async function getStaticPaths() {
 // Default `related` to an empty array so the page renders safely if the
 // dev server's content collection cache goes stale between HMR passes.
 const { article, related = [] } = Astro.props;
-const { Content } = await render(article);
+
+// Split raw markdown body at structural markers.
+// "# TLDR" and "# Research" are section delimiters — omitted from rendered output.
+const body = article.body ?? '';
+const tldrMatch = body.match(/^#\s*TLDR\s*$/m);
+const researchMatch = body.match(/^#\s*Research\s*$/m);
+
+const storyMd = (tldrMatch && researchMatch)
+  ? body.slice(tldrMatch.index! + tldrMatch[0].length, researchMatch.index).trim()
+  : '';
+
+const deepMd = researchMatch
+  ? body.slice(researchMatch.index! + researchMatch[0].length).trim()
+  : body.trim();
+
+const storyHtml = String(marked.parse(storyMd));
+const deepHtml = String(marked.parse(deepMd));
 
 // Single source of truth for badge + tint comes from src/lib/categories.ts.
 // `badge` is the inline-style string for the category pill; `tintFor()` returns
@@ -118,41 +135,9 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
         </Cluster>
       </Stack>
 
-      <!--
-        Content version selector — UI scaffolding only. The Short Read /
-        Deep Dive split ships when dime emits the short version; for now
-        Deep Dive is the only content variant. See ticket for details.
-      -->
-      <div class="flex gap-sm mt-xl border-t border-outline-variant pt-lg">
-        <!-- Short Read (inactive) -->
-        <div class="flex-1 text-left p-md bg-surface-container text-on-surface cursor-default">
-          <div class="uppercase font-bold tracking-widest opacity-60 mb-2xs" style="font-family: var(--font-headline); font-size: var(--text-caption)">
-            Short Read
-          </div>
-          <div class="font-bold leading-tight" style="font-family: var(--font-headline); font-size: var(--text-body-lg)">
-            The Story
-          </div>
-          <div class="h-1 w-0 bg-primary-container mt-sm"></div>
-        </div>
-        <!-- Deep Dive (active) -->
-        <div class="flex-1 text-left p-md bg-white border-b-4 border-primary-container shadow-md cursor-default">
-          <div class="uppercase font-bold tracking-widest text-primary-md mb-2xs" style="font-family: var(--font-headline); font-size: var(--text-caption)">
-            Full Research
-          </div>
-          <div class="font-bold leading-tight text-on-surface" style="font-family: var(--font-headline); font-size: var(--text-body-lg)">
-            Deep Dive
-          </div>
-          <div class="h-1 w-full bg-primary-container mt-sm"></div>
-        </div>
-      </div>
     </div>
 
-    <!-- Article body: parchment background -->
-    <article class="bg-parchment py-2xl md:py-section-y px-container-x md:px-0">
-      <Prose>
-        <Content />
-      </Prose>
-    </article>
+    <ArticleContent {storyHtml} {deepHtml} client:load />
 
     <!-- Related articles -->
     {related.length > 0 && (
@@ -162,7 +147,7 @@ const dateStr = article.data.date.toLocaleDateString("en-US", {
         </div>
         <Grid cols="1 md:3" gap="lg">
           {related.map((rel) => {
-            const tint = tintFor(rel.data.category);
+            const tint = tintFor(rel.data.category ?? "");
             const relBadge = badgeStyle(rel.data.category);
             const relCat = CATEGORIES[rel.data.category as CategorySlug];
             return (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -67,13 +67,13 @@ const articles = (await getCollection("articles", ({ data }) => !data.draft))
         </p>
       </Center>
     ) : (
-      <Grid as="ul" class="list-none p-0">
+      <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-card-gap list-none p-0">
         {articles.map((article) => (
           <li>
             <ArticleCard article={article} />
           </li>
         ))}
-      </Grid>
+      </ul>
     )}
   </Container>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Points content collection glob loader at `../compendium` to read real articles
- Loosens schema to handle flexible date strings like "1920-present"
- Adds `scripts/copy-art.ts` to sync hero images from `../art/` into `public/`
- Fixes ArticleCard: fixed-height text section, line-clamp-2, removes tags display
- Removes `mix-blend-multiply` that was darkening article images
- Adds `ArticleContent.svelte` Svelte 5 island with Story / Deep Dive tab switcher
- Splits article body at `# TLDR` / `# Research` markdown markers; renders with `marked`

Closes #20

## Verification
```bash
bun run dev
# Navigate to any article — verify Story and Deep Dive tabs switch content
# Verify article cards show images, uniform height, no tags
```

## Checklist
- [x] `bun run build` succeeds without errors
- [x] Visually verified at localhost:4321
- [x] Article tab switcher works (Story / Deep Dive)
- [x] Card layout uniform height with line-clamped text
- [x] No secrets committed (images excluded from git)